### PR TITLE
simulation_control: Add two new fields 'by_force'

### DIFF
--- a/proto/ssl_simulation_control.proto
+++ b/proto/ssl_simulation_control.proto
@@ -24,6 +24,9 @@ message TeleportBall {
     optional bool teleport_safely = 7 [default = false];
     // Adapt the angular ball velocity such that the ball is rolling
     optional bool roll = 8 [default = false];
+    // Instead of teleporting the ball, apply some force to make sure
+    // the ball reaches the required position soon (velocity is ignored if true)
+    optional bool by_force = 9 [ default = false];
 }
 
 // Teleport a robot to some location and give it a velocity
@@ -46,6 +49,9 @@ message TeleportRobot {
     // true -> robot will be added, if it does not exist yet
     // false -> robot will be removed, if it is present
     optional bool present = 8;
+    // Instead of teleporting, apply some force to make sure
+    // the robot reaches the required position soon (velocity is ignored if true)
+    optional bool by_force = 9 [ default = false];
 }
 
 // Control the simulation

--- a/proto/ssl_simulation_control.proto
+++ b/proto/ssl_simulation_control.proto
@@ -26,6 +26,11 @@ message TeleportBall {
     optional bool roll = 8 [default = false];
     // Instead of teleporting the ball, apply some force to make sure
     // the ball reaches the required position soon (velocity is ignored if true)
+    // WARNING: A command with by_force stays active (the move will take some time)
+    // until cancled by another TeleportBall command with by_force = false.
+    // To avoid teleporting the ball at the end and resetting its current spin,
+    // do not set any of the optional fields in this message to end the force without triggering
+    // an additional teleportation
     optional bool by_force = 9 [ default = false];
 }
 
@@ -51,6 +56,12 @@ message TeleportRobot {
     optional bool present = 8;
     // Instead of teleporting, apply some force to make sure
     // the robot reaches the required position soon (velocity is ignored if true)
+    // WARNING: A command with by_force stays active (the move will take some time)
+    // until cancled by another TeleportRobot command for the same bot with by_force = false.
+    // To avoid teleporting at the end,
+    // do not set any of the optional fields in this message
+    // to end the force without triggering
+    // an additional teleportation
     optional bool by_force = 9 [ default = false];
 }
 


### PR DESCRIPTION
Currently, it is not possible for our simulator to implement the roll flag in teleport ball.
To model a similar behavior, we just apply some external force in the given direction and let the normal physics figure out how the ball should behave.

To be able to send a command to apply an external force instead of teleporting the ball, we offer this additional bool.

Creating a new message was considered, but as p_x, p_y and p_z are used the same way we think it is easier to use the same message instead of creating a new submessage or duplicating these. The comment explains that the velocity will be ignored if by_force is set to true.