### PR TITLE
Erforce custom specs: (Re-)add dribbler width

### DIFF
--- a/proto/erforce/ssl_simulation_custom_erforce_robot_spec.proto
+++ b/proto/erforce/ssl_simulation_custom_erforce_robot_spec.proto
@@ -4,8 +4,10 @@ option go_package = "github.com/RoboCup-SSL/ssl-simulation-protocol/pkg/sim";
 // Custom robot specs for ER-Force simulator
 message RobotSpecErForce {
     // The distance [m] from the robot center to the ball, when the ball is as close as possible to the robot.
-    // The ball may be a little bit inside the roboter when looking from top, due to the dimensions of the dribbler.
-    optional float shoot_radius = 1;
+    // The ball may be a little bit inside the robot when looking from top, due to the dimensions of the dribbler.
+    required float shoot_radius = 1;
     // The height of the dribbling bar from the ground [m]
-    optional float dribbler_height = 2;
+    required float dribbler_height = 2;
+    // The width of the dribbler itself (where the ball can be controlled), without the mechanical frame [m].
+    required float dribbler_width = 3;
 }


### PR DESCRIPTION
The ERForce simulator simulates a common mesh of an SSL robot.
To do so, we need three different values for the robots front:
A) the actual opening angle (that is convertable from the
center-to-dribbler field in the shared message)
B) the distance robot center to ball center if the ball touches the
robot (this is normally inserted as 'shoot_radius', but without the
balls own radius; This is different from center-to-dribbler as the ball
can get partially inside the center-to-dribbler radius in our (and many)
designs.
C) The actual width of the dribbler (where you can manipulate or shoot
the ball). This is different from the opening angle (or
center-to-dribbler) by the fact that your hull most likly has to have
some way of mounting the dribbler. We also simulate some 'bars' at the
end of the dribbler, so setting this width to exactly your front width
will create some issues.

As the protcoll only has A in the shared message and B in our custom
message, we added C to our custom message aswell.